### PR TITLE
Fix for missing dollar sign on a variable

### DIFF
--- a/gauthify.php
+++ b/gauthify.php
@@ -232,7 +232,7 @@ class GAuthify
          * Returns a single user by ezGAuth token
          */
         $url_addon = 'token/';
-        $params = array('token' => token);
+        $params = array('token' => $token);
         return $this->request_handler('POST', $url_addon, $params);
     }
 


### PR DESCRIPTION
There is a missing dollar sign on the $token variable in the get_user_by_token method
